### PR TITLE
fix: jsdom 版本过低

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:lts
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN npm install
+
+EXPOSE 3000
+
+CMD [ "npm", "start", "3000" ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "highlight.js": "10.0.1",
     "jquery": "3.5.0",
-    "jsdom": "16.2.0",
+    "jsdom": "16.6.0",
     "koa": "2.11.0",
     "koa-body": "^4.1.1",
     "koa-router": "^7.4.0",


### PR DESCRIPTION
修正因 jsdom 版本过低，导致启动时出现的问题 


```
/usr/src/app/node_modules/whatwg-url/dist/URL.js:84
  if (!globalNames.some(globalName => exposed.has(globalName))) {
                   ^

TypeError: Cannot read property 'some' of undefined
```